### PR TITLE
Move Rule 7.4 to "No equivalent"

### DIFF
--- a/MISRA-Rules.md
+++ b/MISRA-Rules.md
@@ -358,7 +358,7 @@ __[See Rule_7_3.rs](./tests/compile-fail/Rule_7_3.rs)__
 
 ### Rule 7.4
 
-✖ **Not enforceable by default**
+✔️ _No equivalent._
 
 __[See Rule_7_4.rs](./tests/compile-fail/Rule_7_4.rs)__
 

--- a/tests/compile-fail/Rule_7_4.rs
+++ b/tests/compile-fail/Rule_7_4.rs
@@ -1,4 +1,2 @@
-fn main() {
-    let mut _l = "string literal";
-    //~^ ERROR Non-compliant - string literal not const-qualified.
-}
+"N/A"
+//~^ ERROR expected item, found `"N/A"`


### PR DESCRIPTION
**Semantically** there are no equivalent Rust code to `char *s = "…";`.

On Rust, we cannot even attempt to modify string literals.

```rust
let mut s = b"byte string literal";

// error[E0594]: cannot assign to `s[_]` which is behind a `&` reference
//s[0] = b'B';

let s = &s[1..]; // this is OK
```

```rust
// equivalents to `char s[] = {…};`
let s = &mut { *b"byte string literal" };
s[0] = b'B'; // `s` is on the stack. so this is not UB
```

```rust
// equivalents to the wrong semantics of `char *s = "…";`
unsafe {
    // Safety:
    //
    // There is always at most 1 pointer to `S`. I promise.
    static mut S: [u8; 19] = *b"byte string literal";
    let s = &mut S;
    s[0] = b'B'; // also this is not UB as long as we obey the "Shared Xor Mutable" rule
}
```